### PR TITLE
Improve local dev setup and update about page sponsor section

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@
 .jekyll-metadata
 _site
 Gemfile.lock
+vendor/bundle
+.bundle
 
 # User-specific files
 *.rsuser

--- a/Gemfile
+++ b/Gemfile
@@ -7,16 +7,14 @@ gem "jekyll-include-cache", group: :jekyll_plugins
 group :jekyll_plugins do
   gem "jekyll-feed"
   gem "jekyll-redirect-from"
-  gem "jekyll-target-blank"
 end
 
-platforms :mingw, :x64_mingw, :mswin, :jruby do
+platforms :windows, :jruby do
   gem "tzinfo", ">= 1", "< 3"
   gem "tzinfo-data"
 end
 
-gem "wdm", :platforms => [:mingw, :x64_mingw, :mswin]
+gem "wdm", :platforms => [:windows]
 gem "http_parser.rb", :platforms => [:jruby]
 gem "webrick"
-gem "open_uri_redirections"
-gem "faraday-retry"
+gem "fiddle"

--- a/Gemfile
+++ b/Gemfile
@@ -18,3 +18,4 @@ gem "wdm", :platforms => [:windows]
 gem "http_parser.rb", :platforms => [:jruby]
 gem "webrick"
 gem "fiddle"
+gem "faraday-retry"

--- a/_config.yml
+++ b/_config.yml
@@ -156,18 +156,6 @@ compress_html:
   clippings: all
   ignore:
     envs: development
-
-# Comments
-comments:
-  provider: "giscus"
-  giscus:
-    repo_id           : "R_kgDOKoNoBw"
-    category_name     : "General"
-    category_id       : "DIC_kwDOKoNoB84C5r2n"
-    discussion_term   : "pathname"
-    reactions_enabled : "1"
-    theme             : "dark"
-
 defaults:
   # _posts
   - scope:
@@ -179,7 +167,6 @@ defaults:
       read_time: true
       share: true
       related: true
-      comments: true
   # _pages
   - scope:
       path: "_pages"

--- a/_config.yml
+++ b/_config.yml
@@ -156,6 +156,18 @@ compress_html:
   clippings: all
   ignore:
     envs: development
+
+# Comments
+comments:
+  provider: "giscus"
+  giscus:
+    repo_id           : "R_kgDOKoNoBw"
+    category_name     : "General"
+    category_id       : "DIC_kwDOKoNoB84C5r2n"
+    discussion_term   : "pathname"
+    reactions_enabled : "1"
+    theme             : "dark"
+
 defaults:
   # _posts
   - scope:
@@ -167,6 +179,7 @@ defaults:
       read_time: true
       share: true
       related: true
+      comments: true
   # _pages
   - scope:
       path: "_pages"

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -45,7 +45,15 @@ Over the years, I’ve been fortunate to work on a wide range of projects, from 
 
 I believe knowledge should be shared, not kept. That’s why I founded Microsoft Playground in 2011 – a blog dedicated to Azure, DevOps, architecture, and hands-on guidance. I also contribute to open-source projects and publish reusable modules and extensions to help others build more effectively in the cloud.
 
-<div class="sponsor-frame"><iframe src="https://github.com/sponsors/maikvandergaag/card" title="Sponsor maikvandergaag" height="225" width="600" style="border: 0;"></iframe></div>
+<div class="sponsor-box">
+  <p>If you find my content helpful, consider sponsoring me on GitHub. Your support helps me keep creating free content, open-source tools, and reusable modules for the community. 💙</p>
+  <a class="sponsor-button" href="https://github.com/sponsors/maikvandergaag" target="_blank" rel="noopener">
+    <svg aria-hidden="true" height="16" viewBox="0 0 16 16" width="16" style="vertical-align:middle;margin-right:6px;fill:#ea4aaa;">
+      <path d="M4.25 2.5c-1.336 0-2.75 1.164-2.75 3 0 2.15 1.58 4.144 3.365 5.682A20.565 20.565 0 008 13.393a20.561 20.561 0 003.135-2.211C12.92 9.644 14.5 7.65 14.5 5.5c0-1.836-1.414-3-2.75-3-1.373 0-2.609.986-3.029 2.456a.75.75 0 01-1.442 0C6.859 3.486 5.623 2.5 4.25 2.5z"/>
+    </svg>
+    Sponsor me on GitHub
+  </a>
+</div>
 
 
 A small set of my certifications:

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -34,3 +34,35 @@ div.highlighter-rouge{
 .layout--home .archive__subtitle{ 
     display:none;
 }
+
+/* Sponsor section */
+.sponsor-box {
+    margin: 1.5em 0;
+    padding: 1.25em 1.5em;
+    border: 1px solid #444;
+    border-radius: 8px;
+    background: rgba(255,255,255,0.04);
+}
+
+.sponsor-box p {
+    margin: 0 0 1em 0;
+}
+
+.sponsor-button {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.5em 1.2em;
+    background: #21262d;
+    color: #f0f6fc !important;
+    border: 1px solid #30363d;
+    border-radius: 6px;
+    font-size: 0.875em;
+    font-weight: 600;
+    text-decoration: none !important;
+    transition: background 0.2s, border-color 0.2s;
+}
+
+.sponsor-button:hover {
+    background: #30363d;
+    border-color: #8b949e;
+}

--- a/run.ps1
+++ b/run.ps1
@@ -51,4 +51,10 @@ if ($Future) {
     Write-Host "Starting Jekyll server..." -ForegroundColor Green
 }
 
+# Open browser after a short delay to allow Jekyll to start
+Start-Job -ScriptBlock {
+    Start-Sleep -Seconds 8
+    Start-Process "http://localhost:4000"
+} | Out-Null
+
 bundle exec jekyll serve @serveArgs

--- a/run.ps1
+++ b/run.ps1
@@ -1,0 +1,54 @@
+# Run script for msftplayground.com (Jekyll)
+# Usage:
+#   .\run.ps1              - Start Jekyll server (published posts only)
+#   .\run.ps1 -Future      - Include future-dated posts
+#   .\run.ps1 -SkipInstall - Skip bundle install check (faster startup)
+
+param(
+    [switch]$Future,
+    [switch]$SkipInstall
+)
+
+# Check if bundler is available
+if (-not (Get-Command bundle -ErrorAction SilentlyContinue)) {
+    Write-Host "Bundler not found. Installing Jekyll and Bundler..." -ForegroundColor Yellow
+    gem install jekyll bundler
+}
+
+# Install dependencies to a short path to avoid Windows MAX_PATH (260 char) limit
+# Skip if -SkipInstall flag is set or if Gemfile hasn't changed since last install
+$gemfilePath = ".\Gemfile"
+$stampFile   = "C:/gems/msftplayground/.install_stamp"
+$needsInstall = $true
+
+if ($SkipInstall) {
+    $needsInstall = $false
+    Write-Host "Skipping bundle install (-SkipInstall)." -ForegroundColor DarkGray
+} elseif ((Test-Path $stampFile) -and (Test-Path $gemfilePath)) {
+    $gemfileTime = (Get-Item $gemfilePath).LastWriteTime
+    $stampTime   = (Get-Item $stampFile).LastWriteTime
+    if ($stampTime -gt $gemfileTime) {
+        $needsInstall = $false
+        Write-Host "Gemfile unchanged, skipping bundle install." -ForegroundColor DarkGray
+    }
+}
+
+if ($needsInstall) {
+    Write-Host "Installing dependencies..." -ForegroundColor Cyan
+    bundle config set --local path 'C:/gems/msftplayground'
+    bundle install
+    # Update stamp so we can skip next time
+    New-Item -ItemType Directory -Force -Path (Split-Path $stampFile) | Out-Null
+    Get-Date | Out-File $stampFile
+}
+
+# Build flags
+$serveArgs = @("--livereload", "--incremental")
+if ($Future) {
+    $serveArgs += "--future"
+    Write-Host "Starting Jekyll server with future posts enabled..." -ForegroundColor Green
+} else {
+    Write-Host "Starting Jekyll server..." -ForegroundColor Green
+}
+
+bundle exec jekyll serve @serveArgs


### PR DESCRIPTION
## Changes

### Local development improvements
- **Run script** (`run.ps1`): Created smart startup script with stamp-file caching to skip `bundle install` when Gemfile is unchanged, `-Future` and `-SkipInstall` flags, `--livereload`, `--incremental`, and auto-opens browser after 8s
- **Gemfile**: Fixed deprecated Windows platform names (`:windows`), added `fiddle` to suppress Ruby 3.5 warning, removed unused gems (`jekyll-target-blank`, `open_uri_redirections`), re-added `faraday-retry` for github-pages health check
- **`.gitignore`**: Added `vendor/bundle`, `.bundle`, `.playwright-mcp`

### About page
- **Sponsor section**: Replaced fixed-width `<iframe>` (broke on mobile) with a responsive sponsor box featuring a GitHub-styled button with heart icon
- **`custom.css`**: Added `.sponsor-box` and `.sponsor-button` styles matching the dark theme