### PR TITLE
Increase posts per page to 10 and fix browser launch timing

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -129,7 +129,7 @@ sass:
   style: compressed # http://sass-lang.com/documentation/file.SASS_REFERENCE.html#output_style
 # Outputting
 permalink: /:categories/:title/
-paginate: 5 # amount of posts to show
+paginate: 10 # amount of posts to show
 paginate_path: /page:num/
 timezone: # http://en.wikipedia.org/wiki/List_of_tz_database_time_zones
 

--- a/run.ps1
+++ b/run.ps1
@@ -51,10 +51,24 @@ if ($Future) {
     Write-Host "Starting Jekyll server..." -ForegroundColor Green
 }
 
-# Open browser after a short delay to allow Jekyll to start
+# Open browser once Jekyll is ready by polling port 4000
 Start-Job -ScriptBlock {
-    Start-Sleep -Seconds 8
-    Start-Process "http://localhost:4000"
+    $timeout = 120
+    $elapsed = 0
+    while ($elapsed -lt $timeout) {
+        try {
+            $tcp = New-Object System.Net.Sockets.TcpClient
+            $tcp.Connect("localhost", 4000)
+            if ($tcp.Connected) {
+                $tcp.Dispose()
+                Start-Process "http://localhost:4000"
+                break
+            }
+            $tcp.Dispose()
+        } catch { }
+        Start-Sleep -Seconds 1
+        $elapsed++
+    }
 } | Out-Null
 
 bundle exec jekyll serve @serveArgs


### PR DESCRIPTION
## Changes

- **Increase pagination**: Changed `paginate` from `5` to `10` in `_config.yml` so the main page shows 10 posts per page.
- **Fix browser launch timing**: Updated `run.ps1` to poll `localhost:4000` via TCP instead of using a fixed 8-second sleep. The browser now opens only when Jekyll is actually ready to serve.