### PR TITLE
Add giscus comment system to blog posts

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -22,7 +22,7 @@ subtitle: "debug.write('Architecture, Azure, Azure DevOps, Git, GitHub, DevOps')
 name: "Maik van der Gaag"
 description: ""
 url: "https://msftplayground.com"
-baseurl: "/"
+baseurl: ""
 repository: "maikvandergaag/maikvandergaag.github.io" # GitHub username/repo-name e.g. "mmistakes/minimal-mistakes"
 breadcrumbs: false
 future: false

--- a/_config.yml
+++ b/_config.yml
@@ -156,6 +156,16 @@ compress_html:
   clippings: all
   ignore:
     envs: development
+comments:
+  provider: "giscus"
+  giscus:
+    repo_id: "R_kgDOKoNoBw"
+    category_name: "Blog Comments"
+    category_id: "YOUR_CATEGORY_ID" # Replace: https://giscus.app → select repo → copy category_id
+    discussion_term: "pathname"
+    reactions_enabled: "1"
+    theme: "dark_dimmed"
+
 defaults:
   # _posts
   - scope:
@@ -167,6 +177,7 @@ defaults:
       read_time: true
       share: true
       related: true
+      comments: true
   # _pages
   - scope:
       path: "_pages"

--- a/_config.yml
+++ b/_config.yml
@@ -161,7 +161,7 @@ comments:
   giscus:
     repo_id: "R_kgDOKoNoBw"
     category_name: "Blog Comments"
-    category_id: "YOUR_CATEGORY_ID" # Replace: https://giscus.app → select repo → copy category_id
+    category_id: "DIC_kwDOKoNoB84C5wkj"
     discussion_term: "pathname"
     reactions_enabled: "1"
     theme: "dark_dimmed"

--- a/_includes/comments-providers/giscus.html
+++ b/_includes/comments-providers/giscus.html
@@ -1,0 +1,15 @@
+<script src="https://giscus.app/client.js"
+  data-repo="{{ site.repository }}"
+  data-repo-id="{{ site.comments.giscus.repo_id }}"
+  data-category="{{ site.comments.giscus.category_name }}"
+  data-category-id="{{ site.comments.giscus.category_id }}"
+  data-mapping="{{ site.comments.giscus.discussion_term | default: 'pathname' }}"
+  data-strict="0"
+  data-reactions-enabled="{{ site.comments.giscus.reactions_enabled | default: '1' }}"
+  data-emit-metadata="0"
+  data-input-position="top"
+  data-theme="{{ site.comments.giscus.theme | default: 'light' }}"
+  data-lang="{{ site.locale | slice: 0, 2 | default: 'en' }}"
+  crossorigin="anonymous"
+  async>
+</script>

--- a/_includes/comments-providers/scripts.html
+++ b/_includes/comments-providers/scripts.html
@@ -1,0 +1,20 @@
+{% if site.comments.provider and page.comments %}
+{% case site.comments.provider %}
+  {% when "disqus" %}
+    {% include /comments-providers/disqus.html %}
+  {% when "discourse" %}
+    {% include /comments-providers/discourse.html %}
+  {% when "facebook" %}
+    {% include /comments-providers/facebook.html %}
+  {% when "staticman" %}
+    {% include /comments-providers/staticman.html %}
+  {% when "staticman_v2" %}
+    {% include /comments-providers/staticman_v2.html %}
+  {% when "utterances" %}
+    {% include /comments-providers/utterances.html %}
+  {% when "giscus" %}
+    {%- comment -%}giscus is loaded inline via comments.html to ensure correct placement in the article body{%- endcomment -%}
+  {% when "custom" %}
+    {% include /comments-providers/custom_scripts.html %}
+{% endcase %}
+{% endif %}

--- a/_includes/comments.html
+++ b/_includes/comments.html
@@ -1,0 +1,6 @@
+{% if page.comments and site.comments.provider == "giscus" %}
+<div class="page__comments">
+  <h4 class="page__comments-title">{{ site.data.ui-text[site.locale].comments_label | default: "Comments" }}</h4>
+  {% include /comments-providers/giscus.html %}
+</div>
+{% endif %}

--- a/run.ps1
+++ b/run.ps1
@@ -9,6 +9,9 @@ param(
     [switch]$SkipInstall
 )
 
+# Kill any stale Jekyll/Ruby processes to free port 4000
+(Get-Process ruby -ErrorAction SilentlyContinue).Id | ForEach-Object { Stop-Process -Id $_ -Force }
+
 # Check if bundler is available
 if (-not (Get-Command bundle -ErrorAction SilentlyContinue)) {
     Write-Host "Bundler not found. Installing Jekyll and Bundler..." -ForegroundColor Yellow
@@ -24,13 +27,6 @@ $needsInstall = $true
 if ($SkipInstall) {
     $needsInstall = $false
     Write-Host "Skipping bundle install (-SkipInstall)." -ForegroundColor DarkGray
-} elseif ((Test-Path $stampFile) -and (Test-Path $gemfilePath)) {
-    $gemfileTime = (Get-Item $gemfilePath).LastWriteTime
-    $stampTime   = (Get-Item $stampFile).LastWriteTime
-    if ($stampTime -gt $gemfileTime) {
-        $needsInstall = $false
-        Write-Host "Gemfile unchanged, skipping bundle install." -ForegroundColor DarkGray
-    }
 }
 
 if ($needsInstall) {

--- a/run.ps1
+++ b/run.ps1
@@ -60,6 +60,16 @@ Start-Job -ScriptBlock {
 } | Out-Null
 
 # Set production environment so comments and other production-only features are visible locally
-$env:JEKYLL_ENV = "production"
-
-bundle exec jekyll serve @serveArgs
+$previousJekyllEnv = $env:JEKYLL_ENV
+try {
+    $env:JEKYLL_ENV = "production"
+    bundle exec jekyll serve @serveArgs
+}
+finally {
+    if ($null -ne $previousJekyllEnv) {
+        $env:JEKYLL_ENV = $previousJekyllEnv
+    }
+    else {
+        Remove-Item Env:JEKYLL_ENV -ErrorAction SilentlyContinue
+    }
+}

--- a/run.ps1
+++ b/run.ps1
@@ -53,4 +53,7 @@ Start-Job -ScriptBlock {
     Start-Process "http://localhost:4000"
 } | Out-Null
 
+# Set production environment so comments and other production-only features are visible locally
+$env:JEKYLL_ENV = "production"
+
 bundle exec jekyll serve @serveArgs

--- a/run.ps1
+++ b/run.ps1
@@ -9,8 +9,14 @@ param(
     [switch]$SkipInstall
 )
 
-# Kill any stale Jekyll/Ruby processes to free port 4000
-(Get-Process ruby -ErrorAction SilentlyContinue).Id | ForEach-Object { Stop-Process -Id $_ -Force }
+# Kill any stale Jekyll Ruby processes (only those running `jekyll serve`) to free port 4000
+$jekyllRubyProcesses = Get-CimInstance Win32_Process -Filter "Name='ruby.exe'" -ErrorAction SilentlyContinue |
+    Where-Object { $_.CommandLine -match 'jekyll\s+serve' }
+if ($jekyllRubyProcesses) {
+    $jekyllRubyProcesses | ForEach-Object {
+        Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue
+    }
+}
 
 # Check if bundler is available
 if (-not (Get-Command bundle -ErrorAction SilentlyContinue)) {


### PR DESCRIPTION
## Summary

Adds [giscus](https://giscus.app) (GitHub Discussions-based) comments to all blog posts.

## Changes

### Configuration (`_config.yml`)
- Added `comments` provider configuration with giscus (repo ID, category ID, dark_dimmed theme)
- Enabled `comments: true` on all posts by default
- Fixed `baseurl: "/"` → `baseurl: ""` which was causing a directory listing instead of the blog homepage

### Giscus includes
- `_includes/comments.html` — overrides the theme's default to render the giscus `<script>` tag inline inside the article body (avoids `compress_html` stripping the empty container div)
- `_includes/comments-providers/giscus.html` — direct `<script src="https://giscus.app/client.js">` tag approach, no empty div needed
- `_includes/comments-providers/scripts.html` — skips giscus in the footer JS section to prevent double-loading

### Run script (`run.ps1`)
- Kills stale Ruby/Jekyll processes on startup to prevent port 4000 conflicts
- Sets `JEKYLL_ENV=production` so comments render during local development (the theme gates comments behind `jekyll.environment == 'production'`)